### PR TITLE
Fix typos in getting-started page.

### DIFF
--- a/docusaurus/docs/02-installation/01-getting-started.mdx
+++ b/docusaurus/docs/02-installation/01-getting-started.mdx
@@ -54,8 +54,8 @@ Alter publish config files, you should read a comment inside config file and edi
 composer require hasura-extra/bundle
 ```
 
-Symfony Flex will help you config và routes, then you need to file
-`config/packages/hasura.yaml` to setting Hasura base uri, admin secret.
+Symfony Flex will automatically add config files and routes, then you need to open
+`config/packages/hasura.yaml` file to set Hasura base uri, admin secret.
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
There is a Vietnamese word left in `getting-started` page, so I make a PR to fix it.