### PR TITLE
Add Kernel for phpunit.

### DIFF
--- a/src/bundle/phpunit.xml.dist
+++ b/src/bundle/phpunit.xml.dist
@@ -2,6 +2,7 @@
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true">
     <php>
+        <server name="KERNEL_CLASS" value="App\Kernel" />
         <env name="SHELL_VERBOSITY" value="-1" />
         <env name="DATABASE_URL" value="postgres://hasura:hasura@localhost:5432/hasura" />
         <env name="HASURA_BASE_URI" value="http://localhost:8080" />

--- a/src/bundle/phpunit.xml.dist
+++ b/src/bundle/phpunit.xml.dist
@@ -2,7 +2,6 @@
 
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true">
     <php>
-        <server name="KERNEL_CLASS" value="App\Kernel" />
         <env name="SHELL_VERBOSITY" value="-1" />
         <env name="DATABASE_URL" value="postgres://hasura:hasura@localhost:5432/hasura" />
         <env name="HASURA_BASE_URI" value="http://localhost:8080" />

--- a/src/bundle/tests/Integration/WebTestCase.php
+++ b/src/bundle/tests/Integration/WebTestCase.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
 namespace Hasura\Bundle\Tests\Integration;
 
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as SymfonyWebTestCase;
+use Hasura\Bundle\Tests\WebTestCase as AbstractWebTestCase;
 
-abstract class WebTestCase extends SymfonyWebTestCase
+abstract class WebTestCase extends AbstractWebTestCase
 {
     protected ?KernelBrowser $client;
 

--- a/src/bundle/tests/WebTestCase.php
+++ b/src/bundle/tests/WebTestCase.php
@@ -1,10 +1,4 @@
 <?php
-/*
- * (c) Tai Vu <vcttai@gmail.com>
- *
- * This source file is subject to the MIT license that is bundled
- * with this source code in the file LICENSE.
- */
 
 declare(strict_types=1);
 
@@ -14,7 +8,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as SymfonyWebTestCase;
 
 abstract class WebTestCase extends SymfonyWebTestCase
 {
-    protected string $projectDir = __DIR__ . '/Fixture';
+    protected string $projectDir = __DIR__.'/Fixture';
 
     public static function getKernelClass()
     {

--- a/src/bundle/tests/WebTestCase.php
+++ b/src/bundle/tests/WebTestCase.php
@@ -1,0 +1,23 @@
+<?php
+/*
+ * (c) Tai Vu <vcttai@gmail.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+declare(strict_types=1);
+
+namespace Hasura\Bundle\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase as SymfonyWebTestCase;
+
+abstract class WebTestCase extends SymfonyWebTestCase
+{
+    protected string $projectDir = __DIR__ . '/Fixture';
+
+    public static function getKernelClass()
+    {
+        return TestKernel::class;
+    }
+}


### PR DESCRIPTION
Currently, PHPUnit is [failed](https://github.com/hasura-extra/hasura-extra/runs/5357736768?check_suite_focus=true) due to `KERNEL_CLASS` variable.
I add a config to fix it.