### PR TITLE
feat!: Improve handle Http exception when running metadata commands.

### DIFF
--- a/src/metadata/src/Command/ApplyMetadata.php
+++ b/src/metadata/src/Command/ApplyMetadata.php
@@ -14,7 +14,6 @@ use Hasura\Metadata\EmptyMetadataException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 
 final class ApplyMetadata extends BaseCommand
 {
@@ -38,7 +37,7 @@ final class ApplyMetadata extends BaseCommand
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->io->section('Applying...');
 
@@ -47,9 +46,6 @@ final class ApplyMetadata extends BaseCommand
             $this->io->success('Apply Hasura metadata successfully!');
 
             return self::SUCCESS;
-        } catch (HttpExceptionInterface $exception) {
-            $this->io->error($exception->getResponse()->getContent(false));
-            $this->io->error(self::INFO_CHECK_SERVER_CONFIG);
         } catch (EmptyMetadataException) {
             if (!$input->getOption('allow-no-metadata')) {
                 $this->io->error('Not found metadata files.');

--- a/src/metadata/src/Command/BaseCommand.php
+++ b/src/metadata/src/Command/BaseCommand.php
@@ -20,8 +20,6 @@ use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 
 abstract class BaseCommand extends Command
 {
-    protected const INFO_CHECK_SERVER_CONFIG = 'Please check your Hasura server configuration.';
-
     protected SymfonyStyle $io;
 
     public function __construct(protected ManagerInterface $metadataManager)
@@ -45,11 +43,7 @@ abstract class BaseCommand extends Command
             $result = $this->doExecute($input, $output);
         } catch (HttpExceptionInterface $exception) {
             $this->io->error($exception->getResponse()->getContent(false));
-            $this->io->error(self::INFO_CHECK_SERVER_CONFIG);
-
-            $result = self::FAILURE;
-        } catch (\Exception $exception) {
-            $this->io->error($exception->getMessage());
+            $this->io->error('Please check your Hasura server configuration.');
 
             $result = self::FAILURE;
         }

--- a/src/metadata/src/Command/ClearMetadata.php
+++ b/src/metadata/src/Command/ClearMetadata.php
@@ -18,7 +18,7 @@ final class ClearMetadata extends BaseCommand
     protected static $defaultName = 'clear';
     protected static $defaultDescription = 'Clear Hasura metadata';
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->io->section('Clearing...');
 

--- a/src/metadata/src/Command/DropInconsistentMetadata.php
+++ b/src/metadata/src/Command/DropInconsistentMetadata.php
@@ -19,7 +19,7 @@ final class DropInconsistentMetadata extends BaseCommand
 
     protected static $defaultDescription = 'Drop inconsistent Hasura metadata';
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->io->section('Dropping...');
 

--- a/src/metadata/src/Command/ExportMetadata.php
+++ b/src/metadata/src/Command/ExportMetadata.php
@@ -13,7 +13,6 @@ namespace Hasura\Metadata\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
 
 final class ExportMetadata extends BaseCommand
 {
@@ -31,20 +30,14 @@ final class ExportMetadata extends BaseCommand
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->io->section('Exporting...');
 
-        try {
-            $this->metadataManager->export($input->getOption('force'));
-            $this->io->success('Export Hasura metadata successfully!');
+        $this->metadataManager->export($input->getOption('force'));
 
-            return self::SUCCESS;
-        } catch (HttpExceptionInterface $exception) {
-            $this->io->error($exception->getResponse()->getContent(false));
-            $this->io->error(self::INFO_CHECK_SERVER_CONFIG);
-        }
+        $this->io->success('Export Hasura metadata successfully!');
 
-        return self::FAILURE;
+        return self::SUCCESS;
     }
 }

--- a/src/metadata/src/Command/GetInconsistentMetadata.php
+++ b/src/metadata/src/Command/GetInconsistentMetadata.php
@@ -18,7 +18,7 @@ final class GetInconsistentMetadata extends BaseCommand
     protected static $defaultName = 'get-inconsistent';
     protected static $defaultDescription = 'Get inconsistent Hasura metadata';
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->io->section('Getting...');
 

--- a/src/metadata/src/Command/PersistState.php
+++ b/src/metadata/src/Command/PersistState.php
@@ -15,7 +15,6 @@ use Hasura\Metadata\StateProcessorInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 
 final class PersistState extends BaseCommand
 {
@@ -36,19 +35,11 @@ final class PersistState extends BaseCommand
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->io->section('Persisting application state to Hasura...');
 
-        try {
-            $this->processor->process($this->metadataManager, $input->getOption('allow-inconsistent'));
-        } catch (ClientExceptionInterface $clientException) {
-            $content = $clientException->getResponse()->getContent(false);
-            $this->io->error($content);
-
-            return self::FAILURE;
-        }
-
+        $this->processor->process($this->metadataManager, $input->getOption('allow-inconsistent'));
         $this->io->success('Persist application states to Hasura successfully!');
 
         return self::SUCCESS;

--- a/src/metadata/src/Command/ReloadMetadata.php
+++ b/src/metadata/src/Command/ReloadMetadata.php
@@ -35,7 +35,7 @@ final class ReloadMetadata extends BaseCommand
         );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output): int
+    protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->io->section('Reloading...');
 


### PR DESCRIPTION
Currently, not all metadata commands are handled `HttpExceptionInterface` if it happened. Therefore I catch it in the base class.