### PR TITLE
add extra env vars

### DIFF
--- a/charts/hasura/Chart.yaml
+++ b/charts/hasura/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - graphql
   - hasura-extra
 type: application
-version: 2.7.0
+version: 2.7.1
 appVersion: "v2.13.0-ce"
 maintainers:
   - name: vuongxuongminh

--- a/charts/hasura/templates/deployment.yaml
+++ b/charts/hasura/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
                 name: {{ include "hasura.fullname" . }}
             - secretRef:
                 name: {{ include "hasura.fullname" . }}
-          {{ - with .Values.extraEnvVars }}
+          {{- with .Values.extraEnvVars }}
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/hasura/templates/deployment.yaml
+++ b/charts/hasura/templates/deployment.yaml
@@ -43,6 +43,10 @@ spec:
                 name: {{ include "hasura.fullname" . }}
             - secretRef:
                 name: {{ include "hasura.fullname" . }}
+          {{ - with .Values.extraEnvVars }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.serverPort }}

--- a/charts/hasura/templates/secret.yaml
+++ b/charts/hasura/templates/secret.yaml
@@ -9,8 +9,7 @@ stringData:
   HASURA_GRAPHQL_DATABASE_URL: {{ tpl .Values.dbUrl $ | quote }}
   HASURA_GRAPHQL_ADMIN_SECRET: {{ .Values.adminSecret | quote }}
 {{- if .Values.jwtSecret }}
-  HASURA_GRAPHQL_JWT_SECRET: |
-    {{ tpl .Values.jwtSecret $ }}
+  HASURA_GRAPHQL_JWT_SECRET: {{ .Values.jwtSecret | toJson | quote }}
   HASURA_GRAPHQL_UNAUTHORIZED_ROLE: {{ .Values.unauthorizedRole | quote }}
 {{- end }}
 {{- with .Values.extraEnvVarsSecret }}

--- a/charts/hasura/values.yaml
+++ b/charts/hasura/values.yaml
@@ -123,6 +123,16 @@ extraEnvVarsCM: {}
 ##   ENV_STORE_IN_SECRET: value
 extraEnvVarsSecret: {}
 
+# -- extraEnvVars append to extra environment variables. See [values.yaml](values.yaml).
+extraEnvVars: []
+# - name: TEST
+#   value: "test"
+# - name: PASSWORD
+#   valueFrom:
+#     secretKeyRef:
+#       name: hasura
+#       key: password
+
 # -- Admin secret key, required to access this instance. This is mandatory when you use webhook or JWT.
 adminSecret: '!ChangeMe!'
 


### PR DESCRIPTION
This PR adds the ability to add extra environment variables, which can be useful to mount secrets created by operators such as the Zalando postgres operator.