### PR TITLE
add >1.23 k8s cluster compatibility

### DIFF
--- a/.github/workflows/helm_chart_tests.yaml
+++ b/.github/workflows/helm_chart_tests.yaml
@@ -49,9 +49,9 @@ jobs:
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm install postgresql bitnami/postgresql \
-            --version ^10.0 \
-            --set postgresqlDatabase=hasura \
-            --set postgresqlPassword=hasura \
+            --version ^12.0 \
+            --set auth.database=hasura \
+            --set auth.postgresPassword=hasura \
             --wait \
             --wait-for-jobs
 

--- a/charts/hasura/Chart.yaml
+++ b/charts/hasura/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - graphql
   - hasura-extra
 type: application
-version: 2.10.0
+version: 2.11.0
 appVersion: "v2.16.0-ce"
 maintainers:
   - name: vuongxuongminh

--- a/charts/hasura/README.md
+++ b/charts/hasura/README.md
@@ -1,6 +1,6 @@
 # Hasura Chart for Kubernetes
 
-![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.16.0-ce](https://img.shields.io/badge/AppVersion-v2.16.0--ce-informational?style=flat-square)
+![Version: 2.11.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.16.0-ce](https://img.shields.io/badge/AppVersion-v2.16.0--ce-informational?style=flat-square)
 
 A Helm chart to install Hasura graphql engine in a Kubernetes cluster.
 

--- a/charts/hasura/templates/hpa.yaml
+++ b/charts/hasura/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: autoscaling/v2
+{{- else -}}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "hasura.fullname" . }}


### PR DESCRIPTION
this chart for hasura doesnt work with autoscaling (HorizontalPodAutoscaler)  enable in >1.23 k8s version.  thats because autoscaling/v2beta1 API has been deprecated.