### PR TITLE
fix hpa structure for k8s >=1.22

### DIFF
--- a/charts/hasura/Chart.yaml
+++ b/charts/hasura/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - graphql
   - hasura-extra
 type: application
-version: 2.11.0
+version: 2.11.1
 appVersion: "v2.16.0-ce"
 maintainers:
   - name: vuongxuongminh

--- a/charts/hasura/README.md
+++ b/charts/hasura/README.md
@@ -1,6 +1,6 @@
 # Hasura Chart for Kubernetes
 
-![Version: 2.11.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.16.0-ce](https://img.shields.io/badge/AppVersion-v2.16.0--ce-informational?style=flat-square)
+![Version: 2.11.1](https://img.shields.io/badge/Version-2.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.16.0-ce](https://img.shields.io/badge/AppVersion-v2.16.0--ce-informational?style=flat-square)
 
 A Helm chart to install Hasura graphql engine in a Kubernetes cluster.
 

--- a/charts/hasura/templates/hpa.yaml
+++ b/charts/hasura/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: autoscaling/v2
 {{- else -}}
 apiVersion: autoscaling/v2beta1
@@ -21,13 +21,24 @@ spec:
     - type: Resource
       resource:
         name: cpu
+        {{- if semverCompare ">=1.22-0" $.Capabilities.KubeVersion.GitVersion }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- else }}
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        {{- if semverCompare ">=1.22-0" .Capabilities.KubeVersion.GitVersion -}}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- else }}
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- end }}
     {{- end }}
 {{- end }}
-


### PR DESCRIPTION
There was 2 issues:
1. with apiVersion autoscaling/v2 there is slightly different structure for metrics
2. changed verification from 1.23 to 1.22 - without that it might be an issue after upgrading cluster from 1.22 to 1.23. Helm would want check resources in missing apiVersion and creates error. 

PS sorry for previous untested completely code.

templates for >=1.22:
```
# Source: hasura/templates/hpa.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: test-hasura
  labels:
    helm.sh/chart: hasura-2.11.1
    app.kubernetes.io/name: hasura
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "v2.16.0-ce"
    app.kubernetes.io/managed-by: Helm
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: test-hasura
  minReplicas: 1
  maxReplicas: 100
  metrics:
    - type: Resource
      resource:
        name: cpu
        target:
          type: Utilization
          averageUtilization: 80
```

tamplates for <1.22:
```
# Source: hasura/templates/hpa.yaml
apiVersion: autoscaling/v2beta1
kind: HorizontalPodAutoscaler
metadata:
  name: test-hasura
  labels:
    helm.sh/chart: hasura-2.11.1
    app.kubernetes.io/name: hasura
    app.kubernetes.io/instance: test
    app.kubernetes.io/version: "v2.16.0-ce"
    app.kubernetes.io/managed-by: Helm
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: test-hasura
  minReplicas: 1
  maxReplicas: 100
  metrics:
    - type: Resource
      resource:
        name: cpu
        targetAverageUtilization: 80
```

          