### PR TITLE
feat!: add support Symfony 8

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - 8.2
+          - 8.4
         actions:
           - name: Composer Validate
             run: composer validate

--- a/.github/workflows/helm_chart_tests.yaml
+++ b/.github/workflows/helm_chart_tests.yaml
@@ -11,30 +11,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # ct needs history to compare
           # https://github.com/helm/chart-testing-action/issues/25
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
-        with:
-          version: v3.7.0
+        uses: azure/setup-helm@v4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: '3.x'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.1.0
+        uses: helm/chart-testing-action@v2.7.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
           changed=$(ct list-changed)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run chart-testing (lint)
@@ -42,7 +40,7 @@ jobs:
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.10.0
 
       - name: Install Postgresql
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/split_monorepo.yaml
+++ b/.github/workflows/split_monorepo.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.4
           coverage: none
 
       - uses: "ramsey/composer-install@v1"

--- a/.github/workflows/split_tests.yaml
+++ b/.github/workflows/split_tests.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.4
           coverage: none
 
       - uses: "ramsey/composer-install@v1"
@@ -45,7 +45,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.4
           coverage: none
 
       - uses: "ramsey/composer-install@v1"

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -16,14 +16,14 @@ jobs:
   unit_tests:
     runs-on: ubuntu-latest
 
-    name: PHP 8.2 tests
+    name: PHP 8.4 tests
 
     steps:
       - uses: actions/checkout@v2
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.4
           coverage: pcov
 
       - uses: "ramsey/composer-install@v1"

--- a/.github/workflows/weekly_pull_request.yaml
+++ b/.github/workflows/weekly_pull_request.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.2
+          php-version: 8.4
           coverage: none
 
       - uses: "ramsey/composer-install@v1"

--- a/composer.json
+++ b/composer.json
@@ -3,28 +3,27 @@
     "license": "MIT",
     "description": "Handle Hasura metadata & business logic in minutes.",
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "psr/event-dispatcher": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-server-handler": "^1.0",
-        "symfony/console": "^7.0",
-        "symfony/dependency-injection": "^7.0",
-        "symfony/filesystem": "^7.0",
-        "symfony/framework-bundle": "^7.0",
-        "symfony/http-client": "^7.0",
-        "symfony/http-kernel": "^7.0",
+        "symfony/console": "^8.0",
+        "symfony/dependency-injection": "^8.0",
+        "symfony/filesystem": "^8.0",
+        "symfony/framework-bundle": "^8.0",
+        "symfony/http-client": "^8.0",
+        "symfony/http-kernel": "^8.0",
         "symfony/psr7-pack": "^1.0",
-        "symfony/string": "^7.0",
-        "symfony/uid": "^7.0",
-        "symfony/yaml": "^7.0",
+        "symfony/string": "^8.0",
+        "symfony/uid": "^8.0",
+        "symfony/yaml": "^8.0",
         "webonyx/graphql-php": "^15.7"
     },
     "require-dev": {
         "nyholm/psr7": "^1.0",
         "phpunit/phpunit": "^10.4",
         "rector/rector": "^0.13.9",
-        "symfony/proxy-manager-bridge": "^6.4",
-        "symfony/security-bundle": "^7.0",
+        "symfony/security-bundle": "^8.0",
         "symfony/test-pack": "^1.0",
         "symplify/easy-coding-standard": "^9.4",
         "symplify/monorepo-builder": "11.1.1"
@@ -54,12 +53,12 @@
         }
     },
     "replace": {
-        "hasura-extra/api-client": "5.0.0",
-        "hasura-extra/auth-hook": "5.0.0",
-        "hasura-extra/bundle": "5.0.0",
-        "hasura-extra/event-dispatcher": "5.0.0",
-        "hasura-extra/graphql-scalars": "5.0.0",
-        "hasura-extra/metadata": "5.0.0"
+        "hasura-extra/api-client": "6.0.0",
+        "hasura-extra/auth-hook": "6.0.0",
+        "hasura-extra/bundle": "6.0.0",
+        "hasura-extra/event-dispatcher": "6.0.0",
+        "hasura-extra/graphql-scalars": "6.0.0",
+        "hasura-extra/metadata": "6.0.0"
     },
     "config": {
         "allow-plugins": {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   apache:
-    image: thecodingmachine/php:8.2-v4-apache
+    image: thecodingmachine/php:8.4-v4-apache
     volumes:
       - ./:/var/www/html:rw,cached
     environment:

--- a/src/api-client/composer.json
+++ b/src/api-client/composer.json
@@ -15,23 +15,23 @@
     },
     "conflict": {
         "hasura-extra/hasura-bundle": "*",
-        "hasura-extra/auth-hook": "<5.0.0",
-        "hasura-extra/event-dispatcher": "<5.0.0",
-        "hasura-extra/bundle": "<5.0.0",
-        "hasura-extra/metadata": "<5.0.0",
+        "hasura-extra/auth-hook": "<6.0.0",
+        "hasura-extra/event-dispatcher": "<6.0.0",
+        "hasura-extra/bundle": "<6.0.0",
+        "hasura-extra/metadata": "<6.0.0",
         "hasura-extra/laravel": "<2.5.0",
-        "hasura-extra/graphql-scalars": "<5.0.0"
+        "hasura-extra/graphql-scalars": "<6.0.0"
     },
     "require": {
-        "php": ">=8.2",
-        "symfony/http-client": "^7.0"
+        "php": ">=8.4",
+        "symfony/http-client": "^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.4"
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "5.1-dev"
+            "dev-main": "6.0-dev"
         }
     },
     "minimum-stability": "dev",

--- a/src/auth-hook/composer.json
+++ b/src/auth-hook/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "psr/http-factory": "^1.0",
         "psr/http-server-handler": "^1.0"
     },
@@ -22,15 +22,15 @@
         "nyholm/psr7": "^1.0"
     },
     "conflict": {
-        "hasura-extra/event-dispatcher": "<5.0.0",
-        "hasura-extra/api-client": "<5.0.0",
-        "hasura-extra/bundle": "<5.0.0",
-        "hasura-extra/metadata": "<5.0.0",
-        "hasura-extra/graphql-scalars": "<5.0.0"
+        "hasura-extra/event-dispatcher": "<6.0.0",
+        "hasura-extra/api-client": "<6.0.0",
+        "hasura-extra/bundle": "<6.0.0",
+        "hasura-extra/metadata": "<6.0.0",
+        "hasura-extra/graphql-scalars": "<6.0.0"
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "5.1-dev"
+            "dev-main": "6.0-dev"
         }
     },
     "minimum-stability": "dev",

--- a/src/bundle/composer.json
+++ b/src/bundle/composer.json
@@ -14,33 +14,32 @@
         }
     },
     "require": {
-        "php": ">=8.2",
-        "hasura-extra/auth-hook": "^5.1",
-        "hasura-extra/api-client": "^5.1",
-        "hasura-extra/metadata": "^5.1",
-        "hasura-extra/event-dispatcher": "^5.1",
-        "symfony/http-kernel": "^7.0",
-        "symfony/dependency-injection": "^7.0",
-        "symfony/framework-bundle": "^7.0",
+        "php": ">=8.4",
+        "hasura-extra/auth-hook": "^6.0",
+        "hasura-extra/api-client": "^6.0",
+        "hasura-extra/metadata": "^6.0",
+        "hasura-extra/event-dispatcher": "^6.0",
+        "symfony/http-kernel": "^8.0",
+        "symfony/dependency-injection": "^8.0",
+        "symfony/framework-bundle": "^8.0",
         "symfony/psr7-pack": "^1.0"
     },
     "require-dev": {
         "nyholm/psr7": "^1.0",
         "phpunit/phpunit": "^10.4",
         "symfony/test-pack": "^1.0",
-        "symfony/uid": "^7.0",
-        "symfony/filesystem": "^7.0",
-        "symfony/security-bundle": "^7.0",
-        "symfony/proxy-manager-bridge": "^6.4"
+        "symfony/uid": "^8.0",
+        "symfony/filesystem": "^8.0",
+        "symfony/security-bundle": "^8.0"
     },
     "conflict": {
         "hasura-extra/hasura-bundle": "*",
         "hasura-extra/laravel": "<2.5.0",
-        "hasura-extra/graphql-scalars": "<5.0.0"
+        "hasura-extra/graphql-scalars": "<6.0.0"
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "5.1-dev"
+            "dev-main": "6.0-dev"
         }
     },
     "minimum-stability": "dev",

--- a/src/bundle/src/Auth/RoleAnonymousVoter.php
+++ b/src/bundle/src/Auth/RoleAnonymousVoter.php
@@ -12,6 +12,7 @@ namespace Hasura\Bundle\Auth;
 
 use Symfony\Component\Security\Core\Authentication\Token\NullToken;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Vote;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
 
 final class RoleAnonymousVoter extends Voter
@@ -20,12 +21,12 @@ final class RoleAnonymousVoter extends Voter
     {
     }
 
-    protected function supports(string $attribute, $subject): bool
+    protected function supports(string $attribute, mixed $subject): bool
     {
         return $attribute === $this->roleAnonymous;
     }
 
-    protected function voteOnAttribute(string $attribute, $subject, TokenInterface $token): bool
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool
     {
         return $token instanceof NullToken;
     }

--- a/src/bundle/src/DependencyInjection/HasuraExtension.php
+++ b/src/bundle/src/DependencyInjection/HasuraExtension.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 
 final class HasuraExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/bundle/tests/Fixture/.gitignore
+++ b/src/bundle/tests/Fixture/.gitignore
@@ -1,2 +1,3 @@
 var
 hasura
+config/reference.php

--- a/src/bundle/tests/TestKernel.php
+++ b/src/bundle/tests/TestKernel.php
@@ -21,7 +21,7 @@ final class TestKernel extends Kernel implements CompilerPassInterface
 {
     use MicroKernelTrait;
 
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $container->getDefinition('hasura.api_client.client')->setPublic(true);
     }

--- a/src/event-dispatcher/composer.json
+++ b/src/event-dispatcher/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "psr/event-dispatcher": "^1.0",
         "psr/http-server-handler": "^1.0"
     },
@@ -22,16 +22,16 @@
         "nyholm/psr7": "^1.0"
     },
     "conflict": {
-        "hasura-extra/auth-hook": "<5.0.0",
-        "hasura-extra/api-client": "<5.0.0",
-        "hasura-extra/bundle": "<5.0.0",
-        "hasura-extra/metadata": "<5.0.0",
+        "hasura-extra/auth-hook": "<6.0.0",
+        "hasura-extra/api-client": "<6.0.0",
+        "hasura-extra/bundle": "<6.0.0",
+        "hasura-extra/metadata": "<6.0.0",
         "hasura-extra/laravel": "<2.5.0",
-        "hasura-extra/graphql-scalars": "<5.0.0"
+        "hasura-extra/graphql-scalars": "<6.0.0"
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "5.1-dev"
+            "dev-main": "6.0-dev"
         }
     },
     "minimum-stability": "dev",

--- a/src/graphql-scalars/composer.json
+++ b/src/graphql-scalars/composer.json
@@ -14,24 +14,24 @@
         }
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.4",
         "webonyx/graphql-php": "^15.7",
-        "symfony/uid": "^7.0"
+        "symfony/uid": "^8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.4"
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "5.1-dev"
+            "dev-main": "6.0-dev"
         }
     },
     "conflict": {
-        "hasura-extra/event-dispatcher": "<5.0.0",
-        "hasura-extra/api-client": "<5.0.0",
-        "hasura-extra/auth-hook": "<5.0.0",
-        "hasura-extra/metadata": "<5.0.0",
-        "hasura-extra/bundle": "<5.0.0"
+        "hasura-extra/event-dispatcher": "<6.0.0",
+        "hasura-extra/api-client": "<6.0.0",
+        "hasura-extra/auth-hook": "<6.0.0",
+        "hasura-extra/metadata": "<6.0.0",
+        "hasura-extra/bundle": "<6.0.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/metadata/composer.json
+++ b/src/metadata/composer.json
@@ -17,26 +17,26 @@
     ],
     "conflict": {
         "hasura-extra/hasura-bundle": "*",
-        "hasura-extra/auth-hook": "<5.0.0",
-        "hasura-extra/event-dispatcher": "<5.0.0",
-        "hasura-extra/bundle": "<5.0.0",
+        "hasura-extra/auth-hook": "<6.0.0",
+        "hasura-extra/event-dispatcher": "<6.0.0",
+        "hasura-extra/bundle": "<6.0.0",
         "hasura-extra/laravel": "<2.5.0",
-        "hasura-extra/graphql-scalars": "<5.0.0"
+        "hasura-extra/graphql-scalars": "<6.0.0"
     },
     "require": {
-        "php": ">=8.2",
-        "symfony/console": "^7.0",
-        "symfony/filesystem": "^7.0",
-        "symfony/string": "^7.0",
-        "symfony/yaml": "^7.0",
-        "hasura-extra/api-client": "^5.1"
+        "php": ">=8.4",
+        "symfony/console": "^8.0",
+        "symfony/filesystem": "^8.0",
+        "symfony/string": "^8.0",
+        "symfony/yaml": "^8.0",
+        "hasura-extra/api-client": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.4"
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "5.1-dev"
+            "dev-main": "6.0-dev"
         }
     },
     "minimum-stability": "dev",

--- a/src/metadata/metadata/remote_schemas.yaml
+++ b/src/metadata/metadata/remote_schemas.yaml
@@ -3,7 +3,7 @@
     definition:
         url: 'https://countries.trevorblades.com/graphql'
         timeout_seconds: 60
-        customization: {  }
+        customization: {}
     comment: ''
     remote_relationships: !include remote_schemas/countries/remote_relationships.yaml
     permissions: !include remote_schemas/countries/permissions.yaml

--- a/src/metadata/metadata/sources/default/tables/public_account.yaml
+++ b/src/metadata/metadata/sources/default/tables/public_account.yaml
@@ -17,7 +17,7 @@ insert_permissions:
     -
         role: manager
         permission:
-            check: {  }
+            check: {}
             columns:
                 - country_code
                 - email
@@ -32,4 +32,4 @@ select_permissions:
                 - name
                 - email
                 - country_code
-            filter: {  }
+            filter: {}

--- a/src/metadata/src/Command/BaseCommand.php
+++ b/src/metadata/src/Command/BaseCommand.php
@@ -27,7 +27,7 @@ abstract class BaseCommand extends Command
         parent::__construct();
     }
 
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $this->io = new SymfonyStyle($input, $output);
     }

--- a/src/metadata/src/Command/ExportMetadata.php
+++ b/src/metadata/src/Command/ExportMetadata.php
@@ -18,10 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'export', description: 'Export Hasura metadata')]
 final class ExportMetadata extends BaseCommand
 {
-    protected static $defaultName = 'export';
-    protected static $defaultDescription = 'Export Hasura metadata';
-
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 

--- a/src/metadata/src/Command/ReloadMetadata.php
+++ b/src/metadata/src/Command/ReloadMetadata.php
@@ -18,7 +18,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 #[AsCommand(name: 'reload', description: 'Reload state with Hasura.')]
 final class ReloadMetadata extends BaseCommand
 {
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
 


### PR DESCRIPTION
## Summary

Adds Symfony 8 support (Symfony 8 only, for simplicity) and prepares the **6.0.0** major release.

### Dependencies
- All `symfony/*` constraints: `^7.0` → `^8.0`; PHP floor: `>=8.2` → `>=8.4` (required by Symfony 8) in the root and all package `composer.json` files.
- Dropped the abandoned `symfony/proxy-manager-bridge` from dev dependencies (incompatible with Symfony 8, unused in code).

### Code fixes (Symfony 8 added native return types / parameters to template methods)
- `Hasura\Metadata\Command\BaseCommand::initialize()`, `ReloadMetadata::configure()`, `ExportMetadata::configure()` → `: void`
- `Hasura\Bundle\DependencyInjection\HasuraExtension::load()` → `: void`
- `Hasura\Bundle\Auth\RoleAnonymousVoter::voteOnAttribute()` → new parent signature `(string $attribute, mixed $subject, TokenInterface $token, ?Vote $vote = null): bool`
- `Hasura\Bundle\Tests\TestKernel::process()` → `: void`
- Removed dead `static $defaultName`/`$defaultDescription` from `ExportMetadata` (inert since Symfony 7)
- Metadata YAML fixtures: empty maps now dumped as `{}` by Symfony Yaml 8 (was `{  }`)

### Version 6.0.0
Version markers pre-applied to match the `monorepo-builder release 6.0.0` worker output: `replace` → `6.0.0`, mutual conflicts → `<6.0.0`, mutual dependencies → `^6.0`, branch aliases → `6.0-dev`. Running `vendor/bin/monorepo-builder release 6.0.0` after merge will no-op on these fields and just tag/push.

### Infrastructure
- CI workflows and docker dev image bumped to PHP 8.4.

## Test plan
- `composer validate` passes for the root and all 6 packages.
- Full PHPUnit suite (325 tests, 545 assertions) passes locally on PHP 8.5 / Symfony 8.1, including api-client/metadata/bundle integration tests against real Hasura containers.
- `hasura-metadata apply` verified end-to-end against Hasura (it fataled on Symfony 8 before the signature fixes).
- `ecs check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)